### PR TITLE
Update reactive.py docstrings

### DIFF
--- a/src/textual/reactive.py
+++ b/src/textual/reactive.py
@@ -405,6 +405,7 @@ class reactive(Reactive[ReactiveType]):
         repaint: Perform a repaint on change.
         init: Call watchers on initialize (post mount).
         always_update: Call watchers even when the new value equals the old value.
+        recompose: Compose the widget again when the attribute changes.
         bindings: Refresh bindings when the reactive changes.
     """
 


### PR DESCRIPTION
Add recompose to docstring for `class reactive(...)`. The text is just copied from the parent-class `Reactive`.


**Please review the following checklist.**

- [x] Docstrings on all new or modified functions / classes - NA
- [ ] Updated documentation - The current [documentation webpage](https://textual.textualize.io/api/reactive/#textual.reactive.reactive) has recompose in the code call but doesn't have the parameter listed in the table below it. I'm assuming that the docs are generated from the actual code and that this fix will update that as well, but tbh don't know. I looked at textual/docs/api/reactive.md and wasn't anything there to update.
- [x] Updated CHANGELOG.md (where appropriate) - Doesn't seem necessary
